### PR TITLE
feat(observability): update OpenAI instrumentation to v2 and upgrade OpenTelemetry dependencies

### DIFF
--- a/.gic
+++ b/.gic
@@ -14,7 +14,7 @@ llm_instructions: |
   [optional footer(s)]
   ~~~
 
-  return ONLY and ONLY the commit message with no ~~~ or ```. You must only return the commit message with no external details.
+  return ONLY and ONLY the commit message with no ~~~ or ```. You must only return the commit message with no external details. DO NOT INCLUDE ANY MESSAGE ABOUT ISSUES.
 
   Example Usage:
 

--- a/app/services/observability.py
+++ b/app/services/observability.py
@@ -14,7 +14,7 @@ from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExport
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
-from opentelemetry.instrumentation.openai import OpenAIInstrumentor
+from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.metrics import Meter, MeterProvider
@@ -88,7 +88,8 @@ def initialize_observability(
         ACTIVE_SERVICE_NAME
 
     if _has_already_init:
-        _main_logger.warning("Attempt made to initialize observability more than once")
+        _main_logger.warning(
+            "Attempt made to initialize observability more than once")
         return
 
     _has_already_init = True
@@ -96,7 +97,8 @@ def initialize_observability(
     run_mode = mode
     _main_logger.info(f"Initializing the observability with mode: {mode}")
     # See this for all the config options using environment variables: https://opentelemetry.io/docs/specs/otel/protocol/exporter/
-    opentelemetry_exporter_otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    opentelemetry_exporter_otlp_endpoint = os.getenv(
+        "OTEL_EXPORTER_OTLP_ENDPOINT")
 
     if opentelemetry_exporter_otlp_endpoint:
         _main_logger.info("🚀 Configuring OTLP telemetry")
@@ -110,9 +112,11 @@ def initialize_observability(
         # setup the instrumentors
         resource = Resource.create(
             attributes={
-                "service.name": service_name,  # https://opentelemetry.io/docs/specs/semconv/resource/#service
+                # https://opentelemetry.io/docs/specs/semconv/resource/#service
+                "service.name": service_name,
                 "service.namespace": "ai.translator",
-                "deployment.environment.name": environment,  # https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/
+                # https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/
+                "deployment.environment.name": environment,
                 "process.pid": str(
                     os.getpid()
                 ),  # https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/
@@ -124,7 +128,8 @@ def initialize_observability(
         # tracing
         trace.set_tracer_provider(
             TracerProvider(
-                resource=resource, sampler=ParentBasedTraceIdRatio(sample_ratio)
+                resource=resource, sampler=ParentBasedTraceIdRatio(
+                    sample_ratio)
             )
         )
         span_processor = BatchSpanProcessor(OTLPSpanExporter())
@@ -144,7 +149,8 @@ def initialize_observability(
         batch_log_record_processor = BatchLogRecordProcessor(OTLPLogExporter())
         logger_provider.add_log_record_processor(batch_log_record_processor)
 
-        handler = LoggingHandler(level=log_level, logger_provider=logger_provider)
+        handler = LoggingHandler(
+            level=log_level, logger_provider=logger_provider)
         # Attach OTLP handler to root logger
         logging.getLogger().addHandler(handler)
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,11 @@ prompty==0.1.34
 python-dotenv==1.0.1
 
 ## OpenTelemetry
-opentelemetry-instrumentation-fastapi==0.48b0
-opentelemetry-api==1.27.0
-opentelemetry-sdk==1.27.0
-opentelemetry-exporter-otlp==1.27.0
-opentelemetry-instrumentation-requests==0.48b0
-opentelemetry-instrumentation-httpx==0.48b0
-opentelemetry-instrumentation-openai==0.33.5 # this is the traceloop one https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai
+opentelemetry-api==1.28.0
+opentelemetry-exporter-otlp==1.28.0
+opentelemetry-instrumentation-fastapi==0.49b0
+opentelemetry-instrumentation-httpx==0.49b0
+opentelemetry-instrumentation-openai-v2==2.0b0
+opentelemetry-instrumentation-requests==0.49b0
+opentelemetry-sdk==1.28.0
+# opentelemetry-instrumentation-openai # this is the traceloop one https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai


### PR DESCRIPTION
This pull request includes updates to the observability service and a minor change to the `.gic` file. The observability service changes involve updating the OpenAI instrumentor and improving code readability by reformatting long lines. The `.gic` file change clarifies the instructions for commit messages.

### Observability Service Updates:

* Updated the OpenAI instrumentor import to use `openai_v2` instead of `openai` in `app/services/observability.py`.
* Reformatted long lines for better readability in the `initialize_observability` function:
  * Warning message about initializing observability more than once.
  * Retrieval of the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable.
  * Resource attributes for service name and deployment environment.
  * Tracer provider initialization with `ParentBasedTraceIdRatio`.
  * Logging handler setup.

![image](https://github.com/user-attachments/assets/aadf0610-2753-4a89-8f95-d2c353c27e72)



### `.gic` File Update:

* Clarified that the commit message should not include any message about issues.